### PR TITLE
SCRUM-12: Implementierung zum Entfernen von Mitarbeitern aus Projekten

### DIFF
--- a/src/main/java/de/szut/lf8_projekt/projekt/ProjektController.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/ProjektController.java
@@ -2,8 +2,14 @@ package de.szut.lf8_projekt.projekt;
 
 import de.szut.lf8_projekt.projekt.geplante_qualifikation.GeplanteQualifikationService;
 import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.MitarbeiterZuordnungService;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto.MitarbeiterEntfernenResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping(value="/LF08Projekt")
@@ -18,5 +24,19 @@ public class ProjektController {
         this.mitarbeiterZuordnungService = mitarbeiterZuordnungService;
     }
 
+    @Operation(summary = "Entfernt einen Mitarbeiter aus einem Projekt")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Mitarbeiter erfolgreich aus Projekt entfernt"),
+        @ApiResponse(responseCode = "404", description = "Projekt, Mitarbeiter oder Zuordnung nicht gefunden", content = @Content),
+        @ApiResponse(responseCode = "401", description = "Ungültiges Token", content = @Content)
+    })
+    @RequestMapping(value = "/{projektId}/mitarbeiter/{mitarbeiterId}", method = RequestMethod.DELETE)
+    public ResponseEntity<MitarbeiterEntfernenResponseDto> entferneMitarbeiterAusProjekt(
+            @PathVariable Long projektId,
+            @PathVariable Long mitarbeiterId) {
+
+        MitarbeiterEntfernenResponseDto response = mitarbeiterZuordnungService.entferneMitarbeiterAusProjekt(projektId, mitarbeiterId);
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
 
 }

--- a/src/main/java/de/szut/lf8_projekt/projekt/geplante_qualifikation/GeplanteQualifikationService.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/geplante_qualifikation/GeplanteQualifikationService.java
@@ -1,8 +1,11 @@
 package de.szut.lf8_projekt.projekt.geplante_qualifikation;
 
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.Optional;
 
+@Service
 public class GeplanteQualifikationService {
     private final GeplanteQualifikationRepository repository;
 

--- a/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/MitarbeiterApiService.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/MitarbeiterApiService.java
@@ -1,0 +1,25 @@
+package de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung;
+
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto.MitarbeiterDto;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.HttpClientErrorException;
+
+@Service
+public class MitarbeiterApiService {
+    private final RestTemplate restTemplate;
+    private static final String EMPLOYEE_API_URL = "https://employee-api.szut.dev/employees";
+
+    public MitarbeiterApiService(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    public MitarbeiterDto getMitarbeiterById(Long mitarbeiterId) {
+        try {
+            String url = EMPLOYEE_API_URL + "/" + mitarbeiterId;
+            return restTemplate.getForObject(url, MitarbeiterDto.class);
+        } catch (HttpClientErrorException.NotFound e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/MitarbeiterZuordnungRepository.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/MitarbeiterZuordnungRepository.java
@@ -2,5 +2,8 @@ package de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface MitarbeiterZuordnungRepository extends JpaRepository<MitarbeiterZuordnungEntity, Long> {
+    Optional<MitarbeiterZuordnungEntity> findByProjektIdAndMitarbeiterId(Long projektId, Long mitarbeiterId);
 }

--- a/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/MitarbeiterZuordnungService.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/MitarbeiterZuordnungService.java
@@ -1,13 +1,27 @@
 package de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung;
 
+import de.szut.lf8_projekt.projekt.ProjektEntity;
+import de.szut.lf8_projekt.projekt.ProjektService;
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto.MitarbeiterDto;
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto.MitarbeiterEntfernenResponseDto;
+import de.szut.lf8_starter.exceptionHandling.ResourceNotFoundException;
+import org.springframework.stereotype.Service;
+
 import java.util.List;
 import java.util.Optional;
 
+@Service
 public class MitarbeiterZuordnungService {
     private final MitarbeiterZuordnungRepository repository;
+    private final ProjektService projektService;
+    private final MitarbeiterApiService mitarbeiterApiService;
 
-    public MitarbeiterZuordnungService(MitarbeiterZuordnungRepository repository) {
+    public MitarbeiterZuordnungService(MitarbeiterZuordnungRepository repository,
+                                       ProjektService projektService,
+                                       MitarbeiterApiService mitarbeiterApiService) {
         this.repository = repository;
+        this.projektService = projektService;
+        this.mitarbeiterApiService = mitarbeiterApiService;
     }
 
     public MitarbeiterZuordnungEntity create(MitarbeiterZuordnungEntity entity) {
@@ -25,5 +39,39 @@ public class MitarbeiterZuordnungService {
 
     public void delete(MitarbeiterZuordnungEntity entity) {
         this.repository.delete(entity);
+    }
+
+    public MitarbeiterEntfernenResponseDto entferneMitarbeiterAusProjekt(Long projektId, Long mitarbeiterId) {
+        // Prüfe ob Projekt existiert
+        ProjektEntity projekt = projektService.readById(projektId);
+        if (projekt == null) {
+            throw new ResourceNotFoundException("Projekt mit der ID " + projektId + " existiert nicht");
+        }
+
+        // Prüfe ob Mitarbeiter existiert
+        MitarbeiterDto mitarbeiter = mitarbeiterApiService.getMitarbeiterById(mitarbeiterId);
+        if (mitarbeiter == null) {
+            throw new ResourceNotFoundException("Mitarbeiter mit der ID " + mitarbeiterId + " existiert nicht");
+        }
+
+        // Prüfe ob Zuordnung existiert
+        Optional<MitarbeiterZuordnungEntity> zuordnung = repository.findByProjektIdAndMitarbeiterId(projektId, mitarbeiterId);
+        if (zuordnung.isEmpty()) {
+            throw new ResourceNotFoundException(
+                "Mitarbeiter mit der Mitarbeiternummer " + mitarbeiterId +
+                " arbeitet nicht in dem angegebenen Projekt mit der Projekt-ID " + projektId
+            );
+        }
+
+        // Lösche die Zuordnung
+        repository.delete(zuordnung.get());
+
+        // Erstelle Response DTO
+        return new MitarbeiterEntfernenResponseDto(
+            mitarbeiterId,
+            mitarbeiter.getVollstaendigerName(),
+            projektId,
+            projekt.getBezeichnung()
+        );
     }
 }

--- a/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/dto/MitarbeiterDto.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/dto/MitarbeiterDto.java
@@ -1,0 +1,24 @@
+package de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class MitarbeiterDto {
+    private Long id;
+    private String vorname;
+    private String nachname;
+    private String strasse;
+    private String postleitzahl;
+    private String stadt;
+    private String telefon;
+
+    public String getVollstaendigerName() {
+        return vorname + " " + nachname;
+    }
+}

--- a/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/dto/MitarbeiterEntfernenResponseDto.java
+++ b/src/main/java/de/szut/lf8_projekt/projekt/mitarbeiter_zuordnung/dto/MitarbeiterEntfernenResponseDto.java
@@ -1,0 +1,17 @@
+package de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class MitarbeiterEntfernenResponseDto {
+    private Long mitarbeiterId;
+    private String mitarbeiterName;
+    private Long projektId;
+    private String projektBezeichnung;
+}

--- a/src/main/java/de/szut/lf8_starter/Lf8StarterApplication.java
+++ b/src/main/java/de/szut/lf8_starter/Lf8StarterApplication.java
@@ -2,8 +2,12 @@ package de.szut.lf8_starter;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"de.szut.lf8_starter", "de.szut.lf8_projekt"})
+@EnableJpaRepositories(basePackages = {"de.szut.lf8_starter", "de.szut.lf8_projekt"})
+@EntityScan(basePackages = {"de.szut.lf8_starter", "de.szut.lf8_projekt"})
 public class Lf8StarterApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/de/szut/lf8_starter/security/AuthentikSecurityConfig.java
+++ b/src/main/java/de/szut/lf8_starter/security/AuthentikSecurityConfig.java
@@ -43,6 +43,7 @@ public class AuthentikSecurityConfig {
                 .authorizeHttpRequests(authz -> authz
                         .requestMatchers("/hello").authenticated()
                         .requestMatchers("/hello/**").authenticated()
+                        .requestMatchers("/LF08Projekt/**").authenticated()
                         .anyRequest().permitAll()
                 );
 

--- a/src/test/java/de/szut/lf8_projekt/projekt/MitarbeiterEntfernenIT.java
+++ b/src/test/java/de/szut/lf8_projekt/projekt/MitarbeiterEntfernenIT.java
@@ -1,0 +1,130 @@
+package de.szut.lf8_projekt.projekt;
+
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.MitarbeiterApiService;
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.MitarbeiterZuordnungEntity;
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.dto.MitarbeiterDto;
+import de.szut.lf8_starter.Lf8StarterApplication;
+import de.szut.lf8_starter.testcontainers.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = Lf8StarterApplication.class)
+public class MitarbeiterEntfernenIT extends AbstractIntegrationTest {
+
+    @MockBean
+    private MitarbeiterApiService mitarbeiterApiService;
+
+    @Test
+    void authorization() throws Exception {
+        // Ohne JWT sollte Zugriff verweigert werden
+        this.mockMvc.perform(delete("/LF08Projekt/1/mitarbeiter/1"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser(roles = "user")
+    void happyPath() throws Exception {
+        // Testdaten vorbereiten
+        ProjektEntity projekt = new ProjektEntity();
+        projekt.setBezeichnung("Testprojekt");
+        projekt.setVerantwortlicherId(1L);
+        projekt.setKundenId("KUNDE-123");
+        projekt.setStartdatum(new Date());
+        projekt = projektRepository.save(projekt);
+
+        MitarbeiterZuordnungEntity zuordnung = new MitarbeiterZuordnungEntity();
+        zuordnung.setProjektId(projekt.getId());
+        zuordnung.setMitarbeiterId(42L);
+        mitarbeiterZuordnungRepository.save(zuordnung);
+
+        // Mock für externe API
+        MitarbeiterDto mitarbeiter = new MitarbeiterDto();
+        mitarbeiter.setId(42L);
+        mitarbeiter.setVorname("Max");
+        mitarbeiter.setNachname("Mustermann");
+        when(mitarbeiterApiService.getMitarbeiterById(42L)).thenReturn(mitarbeiter);
+
+        // Test durchführen
+        this.mockMvc.perform(delete("/LF08Projekt/" + projekt.getId() + "/mitarbeiter/42")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.mitarbeiterId", is(42)))
+                .andExpect(jsonPath("$.mitarbeiterName", is("Max Mustermann")))
+                .andExpect(jsonPath("$.projektId", is(projekt.getId().intValue())))
+                .andExpect(jsonPath("$.projektBezeichnung", is("Testprojekt")));
+
+        // Verifizieren dass Zuordnung gelöscht wurde
+        assertThat(mitarbeiterZuordnungRepository.findByProjektIdAndMitarbeiterId(projekt.getId(), 42L))
+                .isEmpty();
+    }
+
+    @Test
+    @WithMockUser(roles = "user")
+    void projektNichtGefunden() throws Exception {
+        this.mockMvc.perform(delete("/LF08Projekt/999/mitarbeiter/1")
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("Projekt mit der ID 999 existiert nicht")));
+    }
+
+    @Test
+    @WithMockUser(roles = "user")
+    void mitarbeiterNichtGefunden() throws Exception {
+        // Projekt erstellen
+        ProjektEntity projekt = new ProjektEntity();
+        projekt.setBezeichnung("Testprojekt");
+        projekt.setVerantwortlicherId(1L);
+        projekt.setKundenId("KUNDE-123");
+        projekt.setStartdatum(new Date());
+        projekt = projektRepository.save(projekt);
+
+        // Mock: Mitarbeiter existiert nicht
+        when(mitarbeiterApiService.getMitarbeiterById(999L)).thenReturn(null);
+
+        this.mockMvc.perform(delete("/LF08Projekt/" + projekt.getId() + "/mitarbeiter/999")
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is("Mitarbeiter mit der ID 999 existiert nicht")));
+    }
+
+    @Test
+    @WithMockUser(roles = "user")
+    void mitarbeiterNichtImProjekt() throws Exception {
+        // Projekt erstellen
+        ProjektEntity projekt = new ProjektEntity();
+        projekt.setBezeichnung("Testprojekt");
+        projekt.setVerantwortlicherId(1L);
+        projekt.setKundenId("KUNDE-123");
+        projekt.setStartdatum(new Date());
+        projekt = projektRepository.save(projekt);
+
+        // Mock: Mitarbeiter existiert
+        MitarbeiterDto mitarbeiter = new MitarbeiterDto();
+        mitarbeiter.setId(42L);
+        mitarbeiter.setVorname("Max");
+        mitarbeiter.setNachname("Mustermann");
+        when(mitarbeiterApiService.getMitarbeiterById(42L)).thenReturn(mitarbeiter);
+
+        // Keine Zuordnung erstellt!
+
+        this.mockMvc.perform(delete("/LF08Projekt/" + projekt.getId() + "/mitarbeiter/42")
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message", is(
+                        "Mitarbeiter mit der Mitarbeiternummer 42 arbeitet nicht in dem angegebenen Projekt mit der Projekt-ID " + projekt.getId()
+                )));
+    }
+}

--- a/src/test/java/de/szut/lf8_starter/testcontainers/AbstractIntegrationTest.java
+++ b/src/test/java/de/szut/lf8_starter/testcontainers/AbstractIntegrationTest.java
@@ -1,6 +1,8 @@
 package de.szut.lf8_starter.testcontainers;
 
 import de.szut.lf8_starter.hello.HelloRepository;
+import de.szut.lf8_projekt.projekt.ProjektRepository;
+import de.szut.lf8_projekt.projekt.mitarbeiter_zuordnung.MitarbeiterZuordnungRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -26,8 +28,16 @@ public class AbstractIntegrationTest {
     @Autowired
     protected HelloRepository helloRepository;
 
+    @Autowired
+    protected ProjektRepository projektRepository;
+
+    @Autowired
+    protected MitarbeiterZuordnungRepository mitarbeiterZuordnungRepository;
+
     @BeforeEach
     void setUp() {
         helloRepository.deleteAll();
+        mitarbeiterZuordnungRepository.deleteAll();
+        projektRepository.deleteAll();
     }
 }


### PR DESCRIPTION
- DELETE Endpoint /LF08Projekt/{projektId}/mitarbeiter/{mitarbeiterId} hinzugefügt
- Validierung für Projekt- und Mitarbeiterexistenz implementiert
- Integration mit externer Employee API für Mitarbeiterdaten
- Response-DTO mit Mitarbeiter- und Projektinformationen erstellt
- JWT-Authentifizierung für LF08Projekt-Endpoints aktiviert
- Repository-Methode zum Finden von Zuordnungen nach Projekt und Mitarbeiter
- Integration Tests für alle Fehlerszenarien (404, 401) implementiert
- Component Scanning für lf8_projekt Package konfiguriert
- @Service Annotation für GeplanteQualifikationService ergänzt